### PR TITLE
fixes situation when body had a horizontal scroll-bar

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,10 +43,10 @@ export default ({ breakpoints = defaultBreakpoints, unit = 'px' } = {}) => {
   const getWindowWidth = () => {
     switch (unit) {
       case 'px':
-        return document.body.offsetWidth;
+        return document.documentElement.clientWidth;
       case 'em':
         return (
-          document.body.offsetWidth /
+          document.documentElement.clientWidth /
           parseFloat(window.getComputedStyle(document.body).fontSize)
         );
       default:
@@ -60,7 +60,7 @@ export default ({ breakpoints = defaultBreakpoints, unit = 'px' } = {}) => {
   const setState = () => {
     const oldState = Object.assign({}, state); // Cache old state
 
-    const width = getWindowWidth(); // document.body.offsetWidth;
+    const width = getWindowWidth(); // document.documentElement.clientWidth;
     const matchingBreakpoints = breakpoints.filter(bp => width >= bp.minWidth);
 
     // Assign new state values


### PR DESCRIPTION
In situation where the body had a horizontal scroll-bar, and therfor more than 100% of the window-width,
the breakpoint manager returned wrong breakpoints. 
Changing to document.documentElement.clientWidth seems to return the correct width,
also on Chrome-Android, where window.innerWidth is not properly returned during page-load
Link: https://stackoverflow.com/questions/26503816/html-viewport-tag-sometimes-ignored-in-mobile-chrome-on-first-visit